### PR TITLE
Remove stable release version information

### DIFF
--- a/index.html
+++ b/index.html
@@ -53,25 +53,7 @@
 
 			<h2>Download</h2>
 
-			<p>The latest stable release is 0.11.1.</p>
-
 			<p>See <a href="https://github.com/boxbackup/boxbackup/wiki/Installation">the wiki</a> for the latest compilation and installation instructions.</p>
-
-			<ul>
-				<li><b>Stable Release: 0.11.1</b><br />
-				<tt><a href="https://github.com/boxbackup/boxbackup/releases/download/0.11.1/boxbackup-0.11.1.tgz">boxbackup-0.11.1.tgz</a></tt><br />
-				(1.8 MB, SHA256 1328b010477259c4767276dbfebab6580e883336cc9d25696c39991b09cc6d32, released 2 August 2011)</li>
-			</ul>
-
-			<h3>Code Signatures</h3>
-
-			<p>New releases are signed by Chris Wilson (key ID 31197862).
-			<a href="http://pgp.mit.edu:11371/pks/lookup?op=get&search=0x31197862">Download
-			the key</a> or fetch with:</p>
-
-			<pre>
-			gpg --recv-keys --keyserver pgp.mit.edu 31197862
-			</pre>
 
 			<p>Source code is <a href="https://github.com/boxbackup/boxbackup">available on GitHub</a>.</p>
 


### PR DESCRIPTION
The project now recommends users to use a current master branch checkout
rather than a release version.